### PR TITLE
✨ PreAuthorize 설정 및 예제 클래스 작성

### DIFF
--- a/src/main/java/com/example/sogong/domain/member/domain/Member.java
+++ b/src/main/java/com/example/sogong/domain/member/domain/Member.java
@@ -1,6 +1,7 @@
 package com.example.sogong.domain.member.domain;
 
 import com.example.sogong.domain.common.BaseTimeEntity;
+import com.example.sogong.domain.review.domain.Review;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -8,6 +9,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -36,6 +38,9 @@ public class Member extends BaseTimeEntity {
     @Convert(converter = MemberRoleConverter.class)
     private Set<MemberRole> roles = new HashSet<>();
 
+    @OneToMany(mappedBy = "writer", fetch = FetchType.LAZY)
+    private List<Review> reviews;
+
     @Builder
     protected Member(String password, String nickname, String email, Set<MemberRole> roles) {
         this.password = password;
@@ -44,4 +49,7 @@ public class Member extends BaseTimeEntity {
         this.roles = roles;
     }
 
+    public List<Review> getReviews() {
+        return reviews;
+    }
 }

--- a/src/main/java/com/example/sogong/domain/member/service/MemberSearchService.java
+++ b/src/main/java/com/example/sogong/domain/member/service/MemberSearchService.java
@@ -1,0 +1,24 @@
+package com.example.sogong.domain.member.service;
+
+import com.example.sogong.domain.member.domain.Member;
+import com.example.sogong.domain.member.repository.MemberRepository;
+import com.example.sogong.global.common.response.code.ErrorCode;
+import com.example.sogong.global.common.response.exception.GlobalErrorException;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+@Slf4j
+public class MemberSearchService {
+    private final MemberRepository memberRepository;
+
+    public Member findById(Long id) {
+        return memberRepository.findById(id).orElseThrow(
+                () -> new GlobalErrorException(ErrorCode.NOT_FOUND_ERROR)
+        );
+    }
+}

--- a/src/main/java/com/example/sogong/global/common/authorization/PreAuthorizationService.java
+++ b/src/main/java/com/example/sogong/global/common/authorization/PreAuthorizationService.java
@@ -1,0 +1,26 @@
+package com.example.sogong.global.common.authorization;
+
+import com.example.sogong.domain.member.domain.Member;
+import com.example.sogong.domain.member.repository.MemberRepository;
+import com.example.sogong.global.common.response.code.ErrorCode;
+import com.example.sogong.global.common.response.exception.GlobalErrorException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Service("preAuthorizeService")
+@RequiredArgsConstructor
+@Slf4j
+public class PreAuthorizationService {
+    private final MemberRepository memberRepository;
+
+    public boolean isReviewer(Long requestMemberId, Long reviewId) {
+        log.info("requestMemberId = {}, reviewId = {}", requestMemberId, reviewId);
+
+        Member member = memberRepository.findById(requestMemberId).orElseThrow(
+                () -> new GlobalErrorException(ErrorCode.NOT_FOUND_ERROR)
+        );
+
+        return member.getReviews().stream().anyMatch(review -> review.getId().equals(reviewId));
+    }
+}

--- a/src/main/java/com/example/sogong/global/common/response/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/sogong/global/common/response/handler/GlobalExceptionHandler.java
@@ -9,6 +9,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingRequestHeaderException;
@@ -45,6 +46,13 @@ public class GlobalExceptionHandler {
         log.error("handleAuthErrorException : {}", e.getMessage());
         final ErrorResponse response = ErrorResponse.of(e.getErrorCode().getDetail());
         return ResponseEntity.status(e.getErrorCode().getHttpStatus()).body(response);
+    }
+
+    @ExceptionHandler(AccessDeniedException.class)
+    protected ResponseEntity<ErrorResponse> handleAccessDeniedException(AccessDeniedException e) {
+        log.error("handleAccessDeniedException : {}", e.getMessage());
+        final ErrorResponse response = ErrorResponse.of(ErrorCode.FORBIDDEN_ERROR.getMessage());
+        return ResponseEntity.status(HttpStatus.FORBIDDEN).body(response);
     }
 
     /**

--- a/src/main/java/com/example/sogong/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/example/sogong/global/config/security/SecurityConfig.java
@@ -9,6 +9,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
@@ -18,6 +19,7 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 import java.util.Arrays;
 
+@EnableWebSecurity
 @EnableMethodSecurity
 @RequiredArgsConstructor(access = AccessLevel.PROTECTED)
 @Configuration


### PR DESCRIPTION
## 작업 이유
인가 과정 세부 필터

## 작업 사항
딱히 한 게 없어서 너무 민망한 것,,

```java
@Service("preAuthorizeService")
@RequiredArgsConstructor
@Slf4j
public class PreAuthorizationService {
    private final MemberRepository memberRepository;

    public boolean isReviewer(Long requestMemberId, Long reviewId) {
        log.info("requestMemberId = {}, reviewId = {}", requestMemberId, reviewId);

        Member member = memberRepository.findById(requestMemberId).orElseThrow(
                () -> new GlobalErrorException(ErrorCode.NOT_FOUND_ERROR)
        );

        return member.getReviews().stream().anyMatch(review -> review.getId().equals(reviewId));
    }
}
```
위와 같이 PreAuthorization을 처리하는 서비스를 등록했고,  Controller에서 다음과 같이 사용할 수 있슴다.

```java
@PreAuthorize("@preAuthorizeService.test(#securityUser.userId, reviewId)", method = RequestMethod.DELETE)
    @RequestMapping(value = "/reviews/{reviewId}", method = RequestMethod.DELETE)
    public ResponseEntity<?> authenticationTest(
        @AuthenticationPrincipal CustomUserDetails securityUser, 
        @PathVariable("reviewId") Long reviewId) {  
...
}
```

여기서 인증 실패하면 `AccessDeniedException` 예외가 발생하는데, 이건 GlobalExceptionHandler에서 처리하도록 수정했습니다.

![image](https://github.com/SoftwareEngineeringYU/SoftwareEngineering-BE/assets/96044622/38ad3551-3acf-4d76-9264-a6bcab84c993)



## 이슈 연결
close #16 