### PR TITLE
🐛 Swagger접속시 Failed to load remote configuration 에러와 CORS 수정

### DIFF
--- a/src/main/java/com/example/sogong/global/config/SwaggerConfig.java
+++ b/src/main/java/com/example/sogong/global/config/SwaggerConfig.java
@@ -17,7 +17,7 @@ import org.springframework.util.ObjectUtils;
 @OpenAPIDefinition(
         servers = {
             @Server(url = "http://localhost:8080", description = "Local Server"),
-            //@Server(url = "${sogong.domain.backend}", description = "Production Server")
+            @Server(url = "${sogong.domain.backend}", description = "Production Server")
         }
 )
 @RequiredArgsConstructor

--- a/src/main/java/com/example/sogong/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/example/sogong/global/config/security/SecurityConfig.java
@@ -22,6 +22,8 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 import java.util.List;
 
+import static org.springframework.http.HttpHeaders.SET_COOKIE;
+
 
 @EnableWebSecurity
 @EnableMethodSecurity
@@ -83,7 +85,7 @@ class SecurityConfig {
         configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE"));
         configuration.setAllowedHeaders(List.of("*"));
         configuration.setMaxAge(3600L); // Cache preflight
-        configuration.setExposedHeaders(List.of(HttpHeaders.AUTHORIZATION, AuthConstants.REFRESH_TOKEN));
+        configuration.setExposedHeaders(List.of(SET_COOKIE, HttpHeaders.AUTHORIZATION, AuthConstants.REFRESH_TOKEN));
         configuration.setAllowCredentials(true);
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", configuration);

--- a/src/main/java/com/example/sogong/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/example/sogong/global/config/security/SecurityConfig.java
@@ -33,8 +33,8 @@ class SecurityConfig {
 
     private final SecurityAdapterConfig securityAdapterConfig;
 
-    @Value("${app.origin:http://localhost:3000}")
-    private String allowedOrigin;
+    @Value("${app.allow-origins:http://localhost:3000}")
+    private List<String> corsOrigins;
 
     private static final String[] publicEndpoints = {
             // API
@@ -79,9 +79,10 @@ class SecurityConfig {
     @Bean
     CorsConfigurationSource corsConfigurationSource() { // Localhost 환경 cors
         CorsConfiguration configuration = new CorsConfiguration();
-        configuration.setAllowedOrigins(List.of(allowedOrigin));
-        configuration.setAllowedMethods(List.of("GET", "POST", "OPTIONS", "PUT", "PATCH", "DELETE"));
+        configuration.setAllowedOrigins(corsOrigins);
+        configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE"));
         configuration.setAllowedHeaders(List.of("*"));
+        configuration.setMaxAge(3600L); // Cache preflight
         configuration.setExposedHeaders(List.of(HttpHeaders.AUTHORIZATION, AuthConstants.REFRESH_TOKEN));
         configuration.setAllowCredentials(true);
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();

--- a/src/main/java/com/example/sogong/global/config/security/SecurityFilterConfig.java
+++ b/src/main/java/com/example/sogong/global/config/security/SecurityFilterConfig.java
@@ -10,6 +10,7 @@ import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.filter.ForwardedHeaderFilter;
 
 @RequiredArgsConstructor(access = AccessLevel.PROTECTED)
 @Configuration
@@ -30,6 +31,11 @@ class SecurityFilterConfig {
     @Bean
     public TokenBanCheckFilter tokenBanCheckFilter() {
         return new TokenBanCheckFilter(forbiddenTokenService, objectMapper);
+    }
+
+    @Bean
+    ForwardedHeaderFilter forwardedHeaderFilter() {
+        return new ForwardedHeaderFilter();
     }
 
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -52,4 +52,4 @@ app:
     id-code: ${PORTONE_ID_CODE}
     cid: ${PORTONE_CID}
 
-  origin: ${ALLOWED_ORIGIN}
+  allow-origins: ${ALLOWED_ORIGIN}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -53,3 +53,7 @@ app:
     cid: ${PORTONE_CID}
 
   allow-origins: ${ALLOWED_ORIGIN}
+
+sogong:
+  domain:
+    backend: ${BACKEND_API}


### PR DESCRIPTION
## 작업 이유

### 배포한 서버에서 Swagger 접속시, Failed to load remote configuration 에러 발생

  1. `nginx`에서 reverse proxy로 설정한 부분에서 `X-Forwarded-Prefix` 추가

  ```nginxconf
  location /sapi {
      rewrite ^/sapi(.*) $1 break;
      proxy_pass $service_url;
      proxy_set_header X-Real-IP $remote_addr;
      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
      proxy_set_header Host $http_host;
      proxy_set_header X-Forwarded-Prefix /sapi; # <- 추가한 부분
      ...
  ```

  2. 커스텀 헤더를 설정했기 때문에 `ForwardedHeaderFilter`를 bean으로 등록

  ```java
  @Bean
  ForwardedHeaderFilter forwardedHeaderFilter() {
      return new ForwardedHeaderFilter();
  }
  ```


### Swagger 백엔드 주소 추가

전에 재서님이 추가하신 swagger 원격 설정을 위해서 백엔드 배포 주소를 swagger에 추가
```yml
sogong:
  domain:
    backend: ${BACKEND_API}
```


### CORS 오류 수정
  
  `application.yml`에서 허용할 도메인 설정
  
  ```yml
  allow-origins: ${ALLOWED_ORIGIN} # <- http://localhost:3000
  ```

  `SecurityConfig`에서 `OPTIONS` 제거, `AllowedHeaders` 전체 허용

  ```java
  @Bean
  CorsConfigurationSource corsConfigurationSource() {
      configuration.setAllowedOrigins(corsOrigins); // 위의 allow-origins에서 설정한 허용 도메인 리스트
      configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE"));
      configuration.setAllowedHeaders(List.of("*"));
      configuration.setMaxAge(3600L); // Cache preflight
      configuration.setAllowCredentials(true);
  ...
  ```
<br>

  - Axios 설정

```js
axiosInstance.defaults.headers.common["Access-Control-Allow-Origin"] = 서버 도메인;
```

  - 프론트서버에서 `authorization` 헤더로 넘어온 토큰 확인

`response.headers['authorization']`



## 이슈 연결

close #34 